### PR TITLE
Strategy 구현

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/AutoStockPython.iml
+++ b/.idea/AutoStockPython.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="/usr/bin/python3" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="/usr/bin/python3" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="/usr/bin/python3" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/AutoStockPython.iml" filepath="$PROJECT_DIR$/.idea/AutoStockPython.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ $ streamlit run src/autostockpython/frontend/front_stream.py
 $uvicorn src.autostockpython.backend.backend_fast:app --reload
 ```
 
-### 
+###
+ 

--- a/build/lib/autostockpython/backend/backend_fast.py
+++ b/build/lib/autostockpython/backend/backend_fast.py
@@ -22,9 +22,13 @@ app.add_middleware(
 kis_client = KISWebSocketClient()  # 한국투자증권 WebSocket 클라이언트 객체 생성
 yf_dp = YFDataProvider()
 
-@app.get("history")
-def get_history_ticker():
-    return yf_dp.get_info()
+@app.get("/history")
+def get_history_ticker(ticker: str):
+    result = yf_dp.get_info(ticker)
+    if result is not None:
+        return {"ticker": ticker, "price": result}
+    else:
+        return {"error": f"Failed to get information for {ticker}"}
 
 @app.websocket("/ws")
 async def websocket_handler(websocket: WebSocket):

--- a/build/lib/autostockpython/custom/YFDataProvider/YFDataProvider.py
+++ b/build/lib/autostockpython/custom/YFDataProvider/YFDataProvider.py
@@ -3,24 +3,32 @@ from autostockpython.module.DataProvider import DataProvider
 import yfinance as yf
 import json
 from numpyencoder import NumpyEncoder
+from datetime import datetime,timedelta
 
 class YFDataProvider(DataProvider):
     def __init__(self):
         super().__init__()
 
-    def get_info(self, ticker_symbol):
-        #티커 객체 생성
+    def get_info_period(self, ticker_symbol,specific_date,period):
+        if specific_date is None:
+            specific_date = datetime.now().strftime('%Y-%m-%d')
+        
+        # 티커 객체 생성
         ticket = yf.Ticker(ticker_symbol)
-
-        hist = ticket.history(period="1d")
-
+        
+        # 날짜 범위를 조금 넓혀서 데이터를 가져옵니다
+        start_date = (datetime.strptime(specific_date, '%Y-%m-%d') - timedelta(days=period)).strftime('%Y-%m-%d')
+        end_date = (datetime.strptime(specific_date, '%Y-%m-%d'))
+        
+        print(f"Fetching data for {ticker_symbol} from {start_date} to {end_date}")
+        hist = ticket.history(start=start_date, end=end_date)
         if not hist.empty:
-            date_time = hist.index[0]
-            opening_price = hist['Open'].iloc[0]
-            high_price = hist['High'].iloc[0]
-            low_price = hist['Low'].iloc[0]
-            closing_price = hist['Close'].iloc[0]
-            volume = hist['Volume'].iloc[0]
+            date_time = hist.index[-1]
+            opening_price = hist['Open'].iloc[-1]
+            high_price = hist['High'].iloc[-1]
+            low_price = hist['Low'].iloc[-1]
+            closing_price = hist['Close'].iloc[-1]
+            volume = hist['Volume'].iloc[-1]
             
             # JSON 데이터 생성
             json_data = {
@@ -36,7 +44,37 @@ class YFDataProvider(DataProvider):
             return json.dumps(json_data, indent=2, cls=NumpyEncoder)
         else:
             return "데이터를 가져올 수 없습니다."
+        
+    def get_info(self, ticker_symbol,specific_date):
+        if specific_date is None:
+            specific_date = datetime.now().strftime('%Y-%m-%d')
 
+        ticker = yf.Ticker(ticker_symbol)
+        end_date = (datetime.strptime(specific_date, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y-%m-%d")
+        hist = ticker.history(start=specific_date, end=end_date)
+        
+        if not hist.empty:
+            date_time = hist.index[0]
+            opening_price = hist['Open'].iloc[0]
+            high_price = hist['High'].iloc[0]
+            low_price = hist['Low'].iloc[0]
+            closing_price = hist['Close'].iloc[0]
+            volume = hist['Volume'].iloc[0]
+
+            # JSON 데이터 생성
+            json_data = {
+                "market": ticker_symbol,
+                "date_time": date_time.isoformat(),
+                "opening_price": opening_price,
+                "high_price": high_price,
+                "low_price": low_price,
+                "closing_price": closing_price,
+                "acc_price": closing_price * volume,
+                "acc_volume": volume
+            }
+            return json.dumps(json_data, indent=2, cls=NumpyEncoder)
+        else:
+            return "데이터를 가져올 수 없습니다."
     def get_price(self, ticker_symbol):
         try:
             ticker = yf.Ticker(ticker_symbol)

--- a/build/lib/autostockpython/frontend/pages/1_plot.py
+++ b/build/lib/autostockpython/frontend/pages/1_plot.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.title("hello")

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:3a15f3cfff158a313139657493e01459f7b1ead7c1cb511a37e71280c23917c5"
+content_hash = "sha256:e263228e391db864183cc5bdc166a25d678cb918b2af34da4b91ba429f45de19"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -279,7 +279,7 @@ version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
 groups = ["default"]
-marker = "platform_system == \"Windows\" or sys_platform == \"win32\""
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -484,6 +484,17 @@ groups = ["default"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+requires_python = ">=3.7"
+summary = "brain-dead simple config-ini parsing"
+groups = ["default"]
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
 
 [[package]]
@@ -1197,6 +1208,17 @@ files = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.5.0"
+requires_python = ">=3.8"
+summary = "plugin and hook calling mechanisms for python"
+groups = ["default"]
+files = [
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.21.1"
 requires_python = ">=3.8"
@@ -1319,6 +1341,25 @@ files = [
     {file = "pymongo-4.11-cp311-cp311-win32.whl", hash = "sha256:64ad12ae8d79f18ec30d807b9b9b9802c30427c39599d8b1833bc00e63f0e4bb"},
     {file = "pymongo-4.11-cp311-cp311-win_amd64.whl", hash = "sha256:a308ad2eeaee370b3b4154a82840c8f8f9b18ccc76b71812323d243a7bda98a2"},
     {file = "pymongo-4.11.tar.gz", hash = "sha256:21b9969e155c4b16a160fbe90c390a07ca7514479af6c3811b1d15ead26e10ba"},
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+requires_python = ">=3.8"
+summary = "pytest: simple powerful testing with Python"
+groups = ["default"]
+dependencies = [
+    "colorama; sys_platform == \"win32\"",
+    "exceptiongroup>=1.0.0rc8; python_version < \"3.11\"",
+    "iniconfig",
+    "packaging",
+    "pluggy<2,>=1.5",
+    "tomli>=1; python_version < \"3.11\"",
+]
+files = [
+    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
+    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "note>=0.5.2",
     "pycryptodome>=3.21.0",
     "websockets>=14.2",
+    "pytest>=8.3.4",
 ]
 requires-python = "==3.11.*"
 readme = "README.md"

--- a/src/AutoStockPython.egg-info/PKG-INFO
+++ b/src/AutoStockPython.egg-info/PKG-INFO
@@ -10,9 +10,23 @@ Requires-Dist: jupyter>=1.1.1
 Requires-Dist: note>=0.5.2
 Requires-Dist: pycryptodome>=3.21.0
 Requires-Dist: websockets>=14.2
+Requires-Dist: pytest>=8.3.4
 
 ### 기본 자동 매매(Show me the money)(SMTM)
 1. 데이터 수집 : 가격 및 거래 정보, 뉴스, SNS 반응을 수집한다.
 2. 데이터 분석 : 수집한 데이터를 분석하고 매매를 판단한다.
 3. 거래 요청 및 처리 : 매매를 요청하고, 체결된 거래 정보를 처리한다.
-4. 거래 내용 및 결과 분석 : 거래 내용과 결과를 데이터로 기록, 분석한다.
+4. 거래 내용 및 결과 분석 : 거래 내용과 결과를 데이터로 기록, 분석한다
+
+### Streamlit 
+```
+$ streamlit run src/autostockpython/frontend/front_stream.py
+```
+
+### FastAPI
+```
+$uvicorn src.autostockpython.backend.backend_fast:app --reload
+```
+
+###
+ 

--- a/src/autostockpython/custom/KISDataProvider/KISDataProvider.py
+++ b/src/autostockpython/custom/KISDataProvider/KISDataProvider.py
@@ -6,8 +6,6 @@ import json
 import os
 import pandas as pd
 
-import
-
 class KISDataProvider(DataProvider):
     def __init__(self):
         super().__init__()

--- a/src/autostockpython/custom/strategy/StrategyBuyAndHold.py
+++ b/src/autostockpython/custom/strategy/StrategyBuyAndHold.py
@@ -1,0 +1,98 @@
+import copy
+
+from autostockpython.module.Strategy import Strategy
+import logging
+from datetime import datetime, timedelta
+import time
+
+class StrategyBuyAndHold(Strategy):
+    def __init__(self, budget, min_price=5000):
+        self.data = [] # 거래 데이터 리스트
+        self.result = [] # 거래 요청 결과 리스트
+        self.request = [] # 마지막 거래 요청
+        self.waiting_requests = []
+        self.budget = budget
+        self.balance = budget
+        self.min_price = min_price
+        self.is_simulation = False
+        self.logger = logging.getLogger(__name__)
+
+    def update_trading_info(self, info):
+        """
+        거래 정보를 업데이트하는 메서드
+        """
+        self.data.append(copy.deepcopy(info))
+        return info
+
+    def get_request(self):
+        """
+        거래 요청을 생성하는 메서드
+        투자 전략 : 초기 투자금의 1/5만큼씩 매수하는 전략
+        :return: 거래 요청 정보를 담은 딕셔너리
+        """
+        if len(self.data) == 0 or self.data[-1] is None:
+            raise UserWarning("data is empty")
+
+        last_closing_price = self.data[-1]["closing_price"]
+        now = datetime.now().strftime("%Y-%m-%d")
+
+        if self.is_simulation:
+            now = self.data[-1]["date_time"]
+
+        target_budget = self.budget / 5
+        if target_budget > self.balance:
+            target_budget = self.balance
+
+        amount = round(target_budget / last_closing_price, 4)
+        trading_request = {
+            "id" : str(round(time.time(), 3)),
+            "type" : "buy",
+            "price" : last_closing_price,
+            "amount" : amount,
+            "date_time" : now,
+        }
+        total_value = round(float(last_closing_price) * amount)
+
+        if self.min_price > total_value or total_value > self.balance:
+            raise UserWarning("total_value or balance is too small")
+
+        self.logger.info(f"[REQ] id : {trading_request['id']}")
+        self.logger.info(f"=====================")
+        self.logger.info(f"price: {last_closing_price}, amount: {amount}")
+        self.logger.info(f"type: buy, total_value: {total_value}")
+        self.logger.info(f"=====================")
+
+        final_requests = []
+        for request_id in self.waiting_requests:
+            self.logger.info(f"cancel request added! {request_id}")
+            final_requests.append(
+                {
+                    "id" : request_id,
+                    "type" : "cancel",
+                    "price" : 0,
+                    "amount" : 0,
+                    "date_time" : now,
+                }
+            )
+        final_requests.append(trading_request)
+        return final_requests
+
+    def update_result(self, result):
+        """
+        거래 결과를 업데이트하는 메서드 : 투자자가 거래소에 주문을 생성하는 것과 같다.
+        request : 거래 요청 정보
+        result:
+        {
+            "request" : 요청 정보,
+            "type" : 거래 유형 sell, buy, cancel,
+            "price" : 거래 가격,
+            "amount" : 거래 수량,
+            "msg" : 거래 결과 메시지,
+            "state" : 거래 상태 requested, done,
+            "date_time" : 시뮬레이션 모드에서는 데이터 시간 +2초
+        }
+        """
+
+
+
+        pass

--- a/src/autostockpython/module/DataProvider.py
+++ b/src/autostockpython/module/DataProvider.py
@@ -2,7 +2,7 @@ from autostockpython import *
 from abc import ABC, abstractmethod
 import logging
 
-class DataProvider():
+class DataProvider(ABC):
     """
     데이터 소스로부터 데이터를 수집해서 정보를 제공하는 클래스
     """

--- a/src/autostockpython/module/Strategy.py
+++ b/src/autostockpython/module/Strategy.py
@@ -1,0 +1,41 @@
+from autostockpython import *
+from abc import ABC, abstractmethod
+import logging
+
+class Strategy():
+    """
+    데이터 소스로부터 데이터를 수집해서 정보를 제공하는 클래스
+    """
+
+    def __init__(self, budget, min_price=5000):
+        self.data = [] # 거래 데이터 리스트
+        self.result = [] # 거래 요청 결과 리스트
+        self.request = [] # 마지막 거래 요청
+        self.budget = budget
+        self.balance = budget
+        self.min_price = min_price
+        self.logger = logging.getLogger(__name__)
+
+    @abstractmethod
+    def update_trading_info(self):
+        """
+        거래 정보를 업데이트하는 메서드
+        """
+        pass
+
+    @abstractmethod
+    def get_request(self):
+        """
+        거래 요청을 생성하는 메서드
+        :return: 거래 요청 정보를 담은 딕셔너리
+        """
+        pass
+
+    @abstractmethod
+    def update_result(self):
+        """
+        거래 결과를 업데이트하는 메서드
+        :param result: 거래 결과 정보를 담은 딕셔너리
+        """
+
+        pass

--- a/src/autostockpython/module/Strategy.py
+++ b/src/autostockpython/module/Strategy.py
@@ -2,7 +2,7 @@ from autostockpython import *
 from abc import ABC, abstractmethod
 import logging
 
-class Strategy():
+class Strategy(ABC):
     """
     데이터 소스로부터 데이터를 수집해서 정보를 제공하는 클래스
     """

--- a/tests/StrategyTests/test_strategyBuyAndHold.py
+++ b/tests/StrategyTests/test_strategyBuyAndHold.py
@@ -1,3 +1,4 @@
+from autostockpython.custom.strategy.StrategyBuyAndHold import StrategyBuyAndHold
 def test_ITG_get_request_after_update_info_and_results(self):
     #생성과 초기화를 같이 진행
     strategy = StrategyBuyAndHold()

--- a/tests/StrategyTests/test_strategyBuyAndHold.py
+++ b/tests/StrategyTests/test_strategyBuyAndHold.py
@@ -1,0 +1,43 @@
+def test_ITG_get_request_after_update_info_and_results(self):
+    #생성과 초기화를 같이 진행
+    strategy = StrategyBuyAndHold()
+    
+    ### 거래 데이터 리스트
+    strategy.update_trading_info(
+        {
+            "martket" : "KOSPI",
+            "date_time" : "2025-02-14T14:50:31",
+            "opening_price" : "11280.0",
+            "high_price" : "11280.0",
+            "low_price" : "11280.0",
+            "acc_price" : "21512.0"
+            "acc_volume" : "51.812"
+        }
+    )
+
+    request = strategy.get_request()
+    expected_request = {
+        "type" : "buy",
+        "price" : "113040.0",
+        "amount" : "0.009"
+    }
+    # request와 expected_request랑 비교
+    #self.assertEqual(request[0]["type"], expected_request["type"])
+    #self.assertEqual(request[0]["price"], expected_request["price"])
+    strategy.update_result(
+        {"request" : {
+            "id" : request[0]["id"],
+            "type" : "buy",
+            "price" : "113040.0",
+            "amount" : "0.009",
+            "date_time" : "2025-02-14T14:51:00"
+        },
+        "type" : "buy",     
+        "price" : "113040.0",
+        "amount" : "0.009",
+        "msg": "success",
+        "balance": 0,
+        "state" : "done",
+        "date_time" : "2025-02-14T14:51:00"
+        }
+        )

--- a/tests/StrategyTests/test_strategyBuyAndHold.py
+++ b/tests/StrategyTests/test_strategyBuyAndHold.py
@@ -6,21 +6,23 @@ def test_ITG_get_request_after_update_info_and_results(self):
     ### 거래 데이터 리스트
     strategy.update_trading_info(
         {
+            "id" : 1,
             "martket" : "KOSPI",
             "date_time" : "2025-02-14T14:50:31",
-            "opening_price" : "11280.0",
-            "high_price" : "11280.0",
-            "low_price" : "11280.0",
-            "acc_price" : "21512.0"
-            "acc_volume" : "51.812"
+            "opening_price" : 11280.0,
+            "closing_price" : 11500.0,
+            "high_price" : 11280.0,
+            "low_price" : 11280.0,
+            "acc_price" : 21512.0,
+            "acc_volume" : 51.812
         }
     )
 
     request = strategy.get_request()
     expected_request = {
         "type" : "buy",
-        "price" : "113040.0",
-        "amount" : "0.009"
+        "price" : 113040.0,
+        "amount" : 0.009
     }
     # request와 expected_request랑 비교
     #self.assertEqual(request[0]["type"], expected_request["type"])
@@ -29,16 +31,16 @@ def test_ITG_get_request_after_update_info_and_results(self):
         {"request" : {
             "id" : request[0]["id"],
             "type" : "buy",
-            "price" : "113040.0",
-            "amount" : "0.009",
+            "price" : 113040.0,
+            "amount" : 0.009,
             "date_time" : "2025-02-14T14:51:00"
         },
         "type" : "buy",     
-        "price" : "113040.0",
-        "amount" : "0.009",
+        "price" : 113040.0,
+        "amount" : 0.009,
         "msg": "success",
         "balance": 0,
         "state" : "done",
         "date_time" : "2025-02-14T14:51:00"
         }
-        )
+    )


### PR DESCRIPTION
1. 초기 자산을 설정할 수 있다. 
2. 데이터를 입력 받아서 저장한다
-  제공되는 데이터를 입력 받을 때마다 모두 저장하여 이후 분석에 사용한다. 
4. 입력 받은 데이터와 매매 결과를 바탕으로 거래 요청 정보를 생성한다. 
- 데이터와 결과, 자산을 바탕으로 전략에 따른 거래 요청 정보를 생성한다. 
6. 거래 요청 정보는 1개만 유지한다. 
- 이전에 생성한 거래 요청 정보가 완료되지 않았을 경우 새로운 거래 요청 정보를 생성할 때 이전 거래 정보의 취소 요청 정보도 함께 생성하여 전달한다. 
8. 거래 요청의 결과를 저장한다.
- 거래 요청 결과를 모두 저장하여 이후 분석에 사용한다. 
10. 거래  요청의 결과 정보를 통해 자산 현황을 갱신한다.
- 전략에 반영되는 자산 현황은 거래 요청 결과를 통해 갱신한다. 